### PR TITLE
Add universal Codex header template

### DIFF
--- a/codex/templates/codex-header-template.md
+++ b/codex/templates/codex-header-template.md
@@ -1,0 +1,30 @@
+<!-- CODEX_HEADER_START -->
+
+# 🧠 Codex Shard Header
+
+## 🛰️ Location
+- **GPS Approx:** [Latitude, Longitude] *(e.g., 34.7492, -112.1162)*
+- **Field Reference:** *(e.g., Sedona / Shower Vortex Zone, AZ Parent House, Michigan Rainstorm)*
+- **Environment Notes:** *(e.g., indoors, moving vehicle, vortex line-of-sight to kitchen, ceiling fan spin active)*
+
+## 🏷️ Tags
+- *(e.g., resonance, polarity, alignment2, headspace, design, field-stabilization, vortex)*
+
+## 🧬 Emotion State
+- **Primary:** *(e.g., calm, focused, excited, disoriented, expansive)*
+- **Modulation:** *(e.g., “shifting from compressed to open,” “clear after chaos,” “playful but anchored”)*
+
+## 🧩 Identifiers
+- **Shard Name:** `filename.md`
+- **Linked Shards:** *(e.g., `alignment0.md`, `surfacemechanics.md`, `soundhalo-design.md`)*
+- **Codex Type:** `Personal Codex` | `Coding Codex` | `Fusion`
+
+## 💬 Prompt Origin
+```
+[insert exact human prompt here]
+```
+
+## 🔁 Recursion Note
+- *(Optional: What recursive logic or system was in motion? Example: "This emerged from a nested prompt about shower resonance → SoundHalo → vibrational lock headset → need for emotional memory trace in coding output.")*
+
+<!-- CODEX_HEADER_END -->


### PR DESCRIPTION
## Summary
- establish new `codex/templates` folder
- add `codex-header-template.md` with metadata block for new shards

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6852f0910bd483258ea48a02f00acd8b