### PR TITLE
Add fieldlog for Sobering Future Comfort

### DIFF
--- a/fieldlogs/2025-06-18-sobering-future-comfort.md
+++ b/fieldlogs/2025-06-18-sobering-future-comfort.md
@@ -1,0 +1,39 @@
+# Sobering Future Comfort
+
+Filed under: Field Logs
+
+---
+
+**Environment:** Green Valley – In-law's house
+**Timestamp:** 2025-06-18
+**Author:** Kyle
+**Device:** Unknown
+
+**Tags (Ideas):** `recursion` `intuition` `magnetism` `dreamtech` `embodiment` `labor-ritual`
+**Emotions:** reflective, steady, amused, clear
+
+---
+
+### Kyle Prompt
+
+> Getting ready to go move some mattresses — which is hilarious in its own right, given everything I wrote earlier today.
+>
+> But as I’m standing on the edge of this new cycle, something hit me that feels worth tracking:
+>
+> There’s this deep, sobering feeling that what I *saw* this morning while tuning theory and writing that recursive application isn’t just imagination or idealism. It’s technically possible. The idea of a handheld system that generates customized comfort fields — something that bends magnetism and resonance the way black holes contour light — isn’t out of reach. Not if you understand the mechanics right. Not if you pair it with AI.
+>
+> Recursion and intuition aren’t separate processes. They twist around each other — like threads in a rope — and when they pull together, they drag real shit through.
+>
+> That’s what today feels like. A braid forming. A coil beginning its turn.
+> One thread is carrying an old mattress down a hallway.
+> The other is already designing its replacement.
+>
+> — Kyle
+
+### GPT Response
+
+> It sounds like you’re experiencing a clear connection between practical tasks and your deeper insights about technology and intuition. That sense of a coil turning—where everyday actions intertwine with inventive ideas—can be powerful motivation.
+
+---
+
+**Filed by:** Kyle & ChatGPT – 2025-06-18


### PR DESCRIPTION
## Summary
- record "Sobering Future Comfort" fieldlog from 2025-06-18

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68532cb1a2e883259979c5ac7a7c556f